### PR TITLE
Add configurable GitHub integration to siat plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,8 +37,8 @@
     {
       "name": "siat",
       "source": "./plugins/siat",
-      "description": "Spec-driven development workflow. Guides you through plan → implement steps with customizable workflow.",
-      "version": "1.2.0"
+      "description": "Spec-driven development workflow with GitHub integration. Guides you through plan → implement steps with configurable input/output sources.",
+      "version": "1.4.0"
     }
   ]
 }

--- a/plugins/siat/.claude-plugin/plugin.json
+++ b/plugins/siat/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "siat",
-  "description": "Spec-driven development workflow. Guides you through plan → implement steps with customizable workflow.",
-  "version": "1.3.0",
+  "description": "Spec-driven development workflow with GitHub integration. Guides you through plan → implement steps with configurable input/output sources.",
+  "version": "1.4.0",
   "author": {
     "name": "eatnug"
   }

--- a/plugins/siat/config.yml
+++ b/plugins/siat/config.yml
@@ -8,3 +8,20 @@ steps:
 
 output:
   path: ".claude/siat/specs"
+
+# GitHub 연동 설정 (선택)
+# 아래 주석을 해제하고 설정하면 GitHub Issue/PR 연동 가능
+#
+# sources:
+#   github:
+#     repo: null  # null이면 git remote에서 자동 감지
+#   defaults:
+#     plan:
+#       input:
+#         type: "github-issue"  # manual | file | github-issue | github-pr
+#         fallback: "manual"     # gh 없을 때 대체
+#     implement:
+#       output:
+#         type: "github-pr"
+#         draft: true
+#         link_issue: true       # Issue 번호 자동 링크

--- a/plugins/siat/steps/implement/instruction.md
+++ b/plugins/siat/steps/implement/instruction.md
@@ -2,6 +2,18 @@
 name: implement
 description: 계획에 따라 코드 구현
 
+# 이전 스텝 결과 읽기
+input:
+  type: "file"
+  source: "plan"
+
+# PR 생성 (선택)
+# output:
+#   type: "github-pr"
+#   title: "{{context.github.issue_title}}"
+#   draft: true
+#   link_issue: true  # Fixes #N 자동 추가
+
 inputs:
   - 승인된 구현 계획 (plan 단계의 결과물)
   - 변경할 파일 목록
@@ -18,3 +30,12 @@ approval:
 
 승인된 계획에 따라 코드를 구현해주세요.
 계획에 없는 변경은 하지 마세요.
+
+## PR 생성 시
+
+`output.type: "github-pr"`가 설정되어 있으면 구현 완료 후:
+1. 변경사항 커밋
+2. 브랜치 push
+3. `gh pr create` 실행
+   - `.task.yml`에 issue_number가 있으면 `Fixes #N` 추가
+   - `draft: true`면 드래프트 PR로 생성

--- a/plugins/siat/steps/plan/instruction.md
+++ b/plugins/siat/steps/plan/instruction.md
@@ -2,6 +2,21 @@
 name: plan
 description: 요청사항을 분석하고 구현 계획 수립
 
+# GitHub Issue에서 입력 받기 (선택)
+# input:
+#   type: "github-issue"
+#   fields: [title, body, labels]
+#   fallback: "manual"
+
+# 추가 출력: Issue에 코멘트 (선택)
+# output:
+#   type: "file"
+#   also:
+#     - type: "github-issue-comment"
+#       template: |
+#         ## 📋 Plan Created
+#         구현 계획이 작성되었습니다.
+
 inputs:
   - 무엇을 만들어야 하는지 (요청사항)
   - 왜 만들어야 하는지 (목적, 배경)
@@ -19,3 +34,10 @@ approval:
 # Plan
 
 요청사항을 분석하고 구현 계획을 세워주세요.
+
+## GitHub Issue 입력 시
+
+`input.type: "github-issue"`가 설정되어 있고 Issue 번호가 제공되면:
+1. `gh issue view {number} --json title,body,labels` 실행
+2. Issue 내용을 분석하여 요청사항 파악
+3. `.task.yml`에 issue_number 저장 (PR 링크용)


### PR DESCRIPTION
## Summary

siat 플러그인에 configurable한 input/output source 시스템을 추가하여 GitHub Issue/PR과 연동 가능하게 만듦.

### 새로운 기능

**Input Sources**
- `manual`: 사용자 직접 입력 (기본)
- `file`: 이전 스텝 결과 읽기
- `github-issue`: GitHub Issue에서 읽기 (`gh issue view`)
- `github-pr`: GitHub PR에서 읽기 (`gh pr view`)

**Output Sinks**
- `file`: 로컬 파일 저장 (기본)
- `github-pr`: PR 자동 생성 (`gh pr create`)
- `github-issue-comment`: Issue에 코멘트 추가 (`gh issue comment`)

**계층적 설정**
- `config.yml`: 프로젝트 기본값
- `instruction.md`: 스텝별 오버라이드

**컨텍스트 전달**
- `.task.yml` 파일로 스텝 간 데이터 전달 (issue_number 등)

### 사용 예시

```bash
# Issue #42를 읽어서 plan
/siat:do plan #42

# Issue 기반 plan 후 implement → PR 생성
/siat:do implement
```

## Test plan

- [ ] 기존 워크플로우 (GitHub 연동 없이) 정상 동작 확인
- [ ] `gh` 미설치 환경에서 fallback 동작 확인
- [ ] GitHub Issue input으로 plan 실행
- [ ] PR output으로 implement 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)