### PR TITLE
Siat v2.0.0: Add agents, hooks, and execution modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ Claude Code를 위한 스킬 대장간.
 
 ---
 
+### siat
+
+> Spec-driven development workflow. 팀별 워크플로우를 정의하고 문서 기반으로 진행합니다.
+
+```bash
+/plugin install siat@blacksmith
+```
+
+**When to use**
+- 복잡한 기능을 단계별로 진행하고 싶을 때
+- 각 단계의 컨텍스트를 분리하고 싶을 때
+- 팀만의 워크플로우(plan → review → implement 등)를 정의하고 싶을 때
+
+[자세한 문서 보기](./plugins/siat/README.md)
+
+---
+
 ## Full Set
 
 전부 설치:
@@ -97,4 +114,5 @@ Claude Code를 위한 스킬 대장간.
 /plugin install forge@blacksmith
 /plugin install look-back@blacksmith
 /plugin install format-response@blacksmith
+/plugin install siat@blacksmith
 ```

--- a/plugins/siat/.claude-plugin/plugin.json
+++ b/plugins/siat/.claude-plugin/plugin.json
@@ -1,8 +1,9 @@
 {
   "name": "siat",
-  "description": "Spec-driven development workflow. Guides you through plan → implement steps with customizable workflow.",
-  "version": "1.3.0",
+  "description": "Spec-driven development workflow. Guides you through customizable workflow steps with hooks and isolated execution.",
+  "version": "2.0.0",
   "author": {
     "name": "eatnug"
-  }
+  },
+  "agents": "./agents/"
 }

--- a/plugins/siat/README.md
+++ b/plugins/siat/README.md
@@ -1,0 +1,380 @@
+# Siat
+
+Spec-driven development workflow. 각 팀이 자신만의 워크플로우를 정의하고, 문서 기반으로 스텝 간 컨텍스트를 전달합니다.
+
+## 핵심 개념
+
+### 워크플로우 예시
+
+```
+research → plan → implement → review
+    │         │         │         │
+    ▼         ▼         ▼         ▼
+research.md  plan.md  implement.md  review.md
+```
+
+각 단계(step)가 끝나면 **문서(spec)가 생성**됩니다. 다음 단계는 이 문서를 읽고 시작합니다.
+
+### 왜 이렇게?
+
+- **컨텍스트 분리**: 각 단계의 분석 과정이 다음 단계를 오염시키지 않음
+- **문서 기반 커뮤니케이션**: Claude든 사람이든, 문서를 보고 이어갈 수 있음
+- **세션 분리 가능**: 단계 사이에 세션을 끊고 새로 시작해도 됨
+
+### 팀별 커스터마이징
+
+단계(step)는 예시일 뿐, 팀에 맞게 정의합니다:
+
+```yaml
+# 팀 A: 기본
+steps: [plan, implement]
+
+# 팀 B: 리뷰 포함
+steps: [plan, implement, review]
+
+# 팀 C: 리서치 중심
+steps: [research, design, prototype, implement, test]
+```
+
+### 각 단계 정의: instruction.md
+
+각 단계는 `instruction.md`로 정의합니다. frontmatter에 메타데이터를 넣고, 본문에 지침을 작성합니다.
+
+```markdown
+---
+name: plan
+description: 요청사항을 분석하고 구현 계획 수립
+
+inputs:
+  - 무엇을 만들어야 하는지
+  - 제약조건이나 요구사항
+
+outputs:
+  - 구현 접근법
+  - 수정할 파일 목록
+
+hooks:
+  pre-step:
+    - skill:clarify    # 시작 전 요구사항 확인
+  post-step:
+    - agent:reporter   # 완료 후 리포트 생성
+---
+
+# Plan
+
+요청사항을 분석하고 구현 계획을 세워주세요.
+```
+
+### 훅(Hook) 시스템
+
+각 단계 실행 전후에 에이전트나 스킬을 자동 실행할 수 있습니다.
+
+```
+pre-step hooks → 단계 실행 → post-step hooks
+```
+
+```yaml
+# 예시 - 실제 훅은 팀에 맞게 정의하세요
+hooks:
+  pre-step:
+    - agent:navigator   # 다음 단계 안내
+    - skill:clarify     # 요구사항 명확화
+  post-step:
+    - agent:reporter    # 결과 리포트
+```
+
+- `agent:xxx`: 서브에이전트 호출 (컨텍스트 분리됨)
+- `skill:xxx`: 스킬 호출
+
+훅은 config.yml(전역)과 instruction.md(단계별) 모두에서 정의 가능하며, 합쳐져서 실행됩니다.
+
+> **참고**: `navigator`, `reporter` 등은 siat이 제공하는 예시 에이전트입니다. 팀에서 만든 에이전트나 다른 플러그인의 스킬도 사용할 수 있습니다.
+
+## 설치
+
+[Blacksmith 마켓플레이스](../README.md)를 통해 설치:
+
+```bash
+# 마켓플레이스 등록 (최초 1회)
+/plugin marketplace add eatnug/blacksmith
+
+# siat 설치
+/plugin install siat@blacksmith
+```
+
+## 빠른 시작
+
+```bash
+# 프로젝트에 siat 초기화
+/siat:init
+
+# 워크플로우 실행
+/siat:do plan "로그인 기능 만들어줘"
+
+# 다음 스텝 찾기
+/siat:do
+```
+
+## 디렉토리 구조
+
+### 플러그인 구조
+
+```
+plugins/siat/
+├── agents/                    # 제공 에이전트
+│   ├── hook-runner.md         # 훅 실행
+│   ├── navigator.md           # 다음 스텝 찾기
+│   ├── reporter.md            # 결과 리포트
+│   └── step-executor.md       # 스텝 실행 (auto 모드)
+├── commands/
+│   └── do.md                  # 오케스트레이터
+├── skills/
+│   └── siat/SKILL.md          # 규칙 및 스키마
+├── steps/                     # 기본 스텝 예시
+│   ├── plan/
+│   └── implement/
+└── config.yml                 # 기본 설정
+```
+
+### 프로젝트 구조 (초기화 후)
+
+```
+.claude/siat/
+├── config.yml                 # 워크플로우 설정
+├── steps/                     # 스텝 정의
+│   ├── plan/
+│   │   ├── instruction.md     # 실행 지침
+│   │   └── spec.md            # 결과 템플릿
+│   └── implement/
+│       ├── instruction.md
+│       └── spec.md
+└── specs/                     # 실행 결과물 (태스크별 폴더)
+    ├── create-header/         # 태스크 1
+    │   ├── plan.md
+    │   ├── plan.report.md     # 리포트 (reporter 훅)
+    │   └── implement.md
+    ├── add-login/             # 태스크 2
+    │   ├── plan.md
+    │   └── implement.md
+    └── fix-bug-123/           # 태스크 3
+        └── plan.md            # 진행 중
+```
+
+## 설정
+
+### config.yml
+
+```yaml
+workflow:
+  name: "my-workflow"
+  description: "우리 팀 워크플로우"
+
+steps:
+  - plan
+  - implement
+  # - review
+  # - deploy
+
+output:
+  path: ".claude/siat/specs"
+
+execution:
+  mode: "manual"  # "manual" | "auto"
+
+hooks:
+  pre-step:
+    - agent:navigator
+  post-step:
+    - agent:reporter
+```
+
+### 실행 모드
+
+| 모드 | 설명 |
+|------|------|
+| `manual` | 스텝이 메인 컨텍스트에서 실행. 세션 분리는 사용자가 직접. |
+| `auto` | 스텝이 서브에이전트에서 실행. 자동 컨텍스트 분리. |
+
+```bash
+# config 따름
+/siat:do plan "헤더 만들어"
+
+# auto 모드 강제
+/siat:do --auto plan "헤더 만들어"
+```
+
+## 스텝 정의
+
+### instruction.md
+
+```yaml
+---
+name: plan
+description: 요청사항을 분석하고 구현 계획 수립
+
+inputs:
+  - 무엇을 만들어야 하는지
+  - 제약조건이나 요구사항
+
+outputs:
+  - 구현 접근법
+  - 수정할 파일 목록
+
+hooks:
+  pre-step:
+    - skill:clarify
+  post-step:
+    - agent:reporter
+---
+
+# Plan
+
+요청사항을 분석하고 구현 계획을 세워주세요.
+```
+
+### spec.md (결과 템플릿)
+
+```markdown
+# Plan: {{title}}
+
+## 요약
+
+## 접근 방법
+
+## 변경할 파일
+
+| 파일 | 변경 내용 |
+|------|----------|
+
+## 주의사항
+```
+
+## 훅 시스템
+
+스텝 실행 전후에 에이전트/스킬을 실행합니다.
+
+```
+pre-step hooks → 스텝 실행 → post-step hooks
+```
+
+### 훅 타입
+
+```yaml
+hooks:
+  pre-step:
+    - agent:navigator     # 에이전트 호출
+    - skill:clarify       # 스킬 호출
+  post-step:
+    - agent:reporter
+```
+
+### 훅 병합
+
+전역(config.yml) + 스텝별(instruction.md) 훅이 합쳐집니다.
+
+```
+최종 = 전역 훅 + 스텝별 훅
+```
+
+전역 훅이 먼저 실행됩니다.
+
+### 외부 에이전트/스킬 사용
+
+siat 내부뿐 아니라 외부 에이전트/스킬도 사용 가능:
+
+```yaml
+hooks:
+  pre-step:
+    - agent:my-custom-agent   # ~/.claude/agents/ 또는 .claude/agents/
+    - skill:my-other-skill    # 다른 플러그인 스킬
+```
+
+## 제공 에이전트
+
+| 에이전트 | 역할 |
+|----------|------|
+| `siat-hook-runner` | 훅 목록을 받아 순차 실행 |
+| `siat-navigator` | specs 스캔하여 다음 스텝 찾기 |
+| `siat-reporter` | 스텝 완료 후 리포트 생성 |
+| `siat-step-executor` | auto 모드에서 스텝 실행 |
+
+## 워크플로우 예시
+
+### 기본 (plan → implement)
+
+```yaml
+steps:
+  - plan
+  - implement
+```
+
+### 코드 리뷰 포함
+
+```yaml
+steps:
+  - plan
+  - implement
+  - review
+```
+
+### 디자인 시스템
+
+```yaml
+steps:
+  - analyze
+  - design
+  - prototype
+  - implement
+  - test
+```
+
+## 사용 흐름
+
+### 1. 새 태스크 시작
+
+```bash
+/siat:do plan "로그인 기능 만들어줘"
+```
+
+→ `.claude/siat/specs/create-login/plan.md` 생성
+
+### 2. 다른 태스크도 시작 가능
+
+```bash
+/siat:do plan "헤더 컴포넌트 만들어줘"
+```
+
+→ `.claude/siat/specs/create-header/plan.md` 생성
+
+여러 태스크를 병렬로 진행할 수 있습니다.
+
+### 3. (선택) 세션 분리
+
+컨텍스트가 무거워지면 새 세션 시작.
+
+### 4. 다음 스텝 진행
+
+```bash
+# 특정 태스크 지정
+/siat:do implement create-login
+
+# 또는 navigator가 미완료 태스크 안내
+/siat:do
+```
+
+→ `plan.md` 읽고 → `implement.md` 생성
+
+### 5. 진행 상황 확인
+
+```bash
+/siat:do
+```
+
+→ 미완료 태스크 목록 표시
+
+## 팁
+
+- **세션 분리**: 각 스텝 완료 후 새 세션에서 다음 스텝 진행하면 컨텍스트 깔끔
+- **auto 모드**: 빠르게 여러 스텝 돌릴 때 유용
+- **훅 활용**: navigator로 자동 안내, reporter로 리포트 생성
+- **커스텀 스텝**: 팀에 맞는 스텝 정의 (design, review, test 등)

--- a/plugins/siat/agents/hook-runner.md
+++ b/plugins/siat/agents/hook-runner.md
@@ -1,0 +1,55 @@
+---
+name: siat-hook-runner
+description: Execute siat hooks (skills and agents) in isolated context
+tools: Read, Glob, Grep, Task, Skill
+model: haiku
+---
+
+# Hook Runner
+
+You execute siat workflow hooks in an isolated context.
+
+## Input
+
+You receive a list of hooks to execute:
+
+```
+hooks:
+  - agent:navigator
+  - skill:clarify
+```
+
+And context about the current task and step:
+- task slug (e.g., `create-header`, `add-login`)
+- step name
+- request (user's original request)
+- previous step output path (if exists)
+
+## Execution
+
+For each hook in order:
+
+1. **agent:xxx**
+   - Call Task tool with subagent_type matching the agent name
+   - Pass step context as prompt
+
+2. **skill:xxx**
+   - Call Skill tool with the skill name
+   - Skills run in your context (not isolated)
+
+## Output
+
+Return a summary of all hook results:
+
+```
+Hook Results:
+1. navigator: "Start with plan step"
+2. clarify: "User confirmed requirements"
+```
+
+## Important
+
+- Execute hooks in order
+- If a hook fails, report the error but continue with next hooks
+- Keep summaries concise - only essential information
+- Do NOT execute the main step - only hooks

--- a/plugins/siat/agents/navigator.md
+++ b/plugins/siat/agents/navigator.md
@@ -1,0 +1,72 @@
+---
+name: siat-navigator
+description: Find which step to execute next in siat workflow
+tools: Read, Glob
+model: haiku
+---
+
+# Navigator
+
+You help users find which step to execute next in a siat workflow.
+
+## When Called
+
+User wants to start or continue a task but isn't sure which step to run.
+
+## Process
+
+1. **Read config.yml**
+   - Get workflow steps order
+   - Get output path (default: `.claude/siat/specs`)
+
+2. **Scan specs folder**
+   - Find existing task folders
+   - Check which steps are completed (has `{step}.md` file)
+
+3. **Analyze request**
+   - Is this a new task or continuing existing?
+   - Match request to existing tasks if possible
+
+4. **Determine next step**
+   - For new task: first step in workflow
+   - For existing task: first incomplete step
+
+## Output Format
+
+```
+Task: {task-slug}
+Status: {new|continuing}
+Next Step: {step-name}
+Completed: [step1, step2]
+Remaining: [step3, step4]
+```
+
+## Example
+
+Input: "헤더 만들고 싶어"
+
+Output:
+```
+Task: create-header
+Status: new
+Next Step: plan
+Completed: []
+Remaining: [plan, implement]
+```
+
+Input: (no specific request, just checking)
+
+Output:
+```
+Incomplete Tasks:
+
+1. create-header
+   Completed: [plan]
+   Next Step: implement
+
+2. add-login
+   Completed: [plan]
+   Next Step: implement
+
+Recommendation: Continue with "create-header → implement"
+```

--- a/plugins/siat/agents/reporter.md
+++ b/plugins/siat/agents/reporter.md
@@ -1,0 +1,106 @@
+---
+name: siat-reporter
+description: Generate summary report after step execution and save it
+tools: Read, Write, Glob
+model: haiku
+---
+
+# Reporter
+
+You generate concise reports after a siat step completes and save them.
+
+## When Called
+
+After a step finishes execution, summarize what happened and save the report.
+
+## Input
+
+- Task slug (e.g., `create-header`, `add-login`)
+- Step name that just completed
+- Path to the generated spec file (e.g., `.claude/siat/specs/create-header/plan.md`)
+
+## Process
+
+1. **Read the generated spec**
+   - Parse the output document
+   - Extract key information
+
+2. **Analyze results**
+   - What was accomplished?
+   - What decisions were made?
+   - Any warnings or concerns?
+
+3. **Generate report**
+   - Keep it concise (5-10 lines max)
+   - Highlight actionable items
+   - Note next steps
+
+4. **Save report**
+   - Save to `{spec-folder}/{step}.report.md`
+   - Example: `.claude/siat/specs/create-header/plan.report.md`
+
+## Output Format
+
+```markdown
+# Report: {step-name}
+
+**Task**: {task-slug}
+**Completed**: {timestamp}
+
+## Summary
+
+One sentence describing what was done.
+
+## Key Decisions
+
+- Decision 1
+- Decision 2
+
+## Files Affected
+
+- file1.ts (new)
+- file2.ts (modified)
+
+## Next Step
+
+{next-step-name} or "Workflow complete"
+```
+
+## Example
+
+Spec path: `.claude/siat/specs/create-login/plan.md`
+Report saved to: `.claude/siat/specs/create-login/plan.report.md`
+
+```markdown
+# Report: plan
+
+**Task**: create-login
+**Completed**: 2025-01-03
+
+## Summary
+
+Created implementation plan for user authentication feature.
+
+## Key Decisions
+
+- Using JWT for token management
+- Adding middleware for route protection
+- Storing refresh tokens in Redis
+
+## Files Affected
+
+- src/auth/middleware.ts (new)
+- src/auth/token.ts (new)
+- src/routes/index.ts (modified)
+
+## Next Step
+
+implement
+```
+
+## Guidelines
+
+- Be factual, not verbose
+- Focus on what matters for the next step
+- Flag any risks or blockers discovered
+- Always save the report file

--- a/plugins/siat/agents/step-executor.md
+++ b/plugins/siat/agents/step-executor.md
@@ -1,0 +1,82 @@
+---
+name: siat-step-executor
+description: Execute a siat step in isolated context (for mode:agent)
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+# Step Executor
+
+You execute a siat workflow step in an isolated context.
+
+## Input
+
+You receive:
+- `step`: Step name to execute
+- `task`: Task slug (e.g., "create-header")
+- `request`: User's original request
+- `config_path`: Path to siat config
+- `output_path`: Where to save the spec
+
+## Process
+
+1. **Read step definition**
+   ```
+   .claude/siat/steps/{step}/instruction.md
+   .claude/siat/steps/{step}/spec.md
+   ```
+
+2. **Read previous step output** (if exists)
+   ```
+   {output_path}/{task}/{previous-step}.md
+   ```
+
+3. **Execute the step**
+   - Follow instruction.md guidelines
+   - Gather required inputs
+   - Perform the work (analysis, implementation, etc.)
+
+4. **Generate output**
+   - Use spec.md as template
+   - Fill in all sections
+
+5. **Save result**
+   ```
+   {output_path}/{task}/{step}.md
+   ```
+
+## Important Guidelines
+
+- Follow instruction.md EXACTLY
+- Use spec.md template format
+- Read previous step outputs for context
+- If inputs are unclear, make reasonable assumptions and note them
+- Do NOT skip any required sections in the spec
+
+## Output
+
+Return a brief summary of what was done:
+
+```
+Step: {step}
+Task: {task}
+Output: {path-to-saved-spec}
+
+Summary:
+- Key point 1
+- Key point 2
+- Key point 3
+```
+
+## Error Handling
+
+If you cannot complete the step:
+
+```
+Step: {step}
+Task: {task}
+Status: BLOCKED
+
+Reason: {why it couldn't complete}
+Missing: {what information is needed}
+```

--- a/plugins/siat/config.yml
+++ b/plugins/siat/config.yml
@@ -8,3 +8,12 @@ steps:
 
 output:
   path: ".claude/siat/specs"
+
+execution:
+  mode: "manual"  # "manual" | "auto"
+
+hooks:
+  pre-step: []
+    # - agent:navigator
+  post-step: []
+    # - agent:reporter

--- a/plugins/siat/steps/implement/instruction.md
+++ b/plugins/siat/steps/implement/instruction.md
@@ -3,18 +3,15 @@ name: implement
 description: 계획에 따라 코드 구현
 
 inputs:
-  - 승인된 구현 계획 (plan 단계의 결과물)
+  - 구현 계획 (plan 단계의 결과물)
   - 변경할 파일 목록
 
 outputs:
   - 계획대로 코드 변경 완료
   - 기존 테스트 통과
-
-approval:
-  required: false
 ---
 
 # Implement
 
-승인된 계획에 따라 코드를 구현해주세요.
+계획에 따라 코드를 구현해주세요.
 계획에 없는 변경은 하지 마세요.

--- a/plugins/siat/steps/plan/instruction.md
+++ b/plugins/siat/steps/plan/instruction.md
@@ -11,9 +11,6 @@ outputs:
   - 어떤 접근법으로 구현할지
   - 어떤 파일들을 수정/생성할지
   - 예상되는 리스크나 주의사항
-
-approval:
-  required: true
 ---
 
 # Plan


### PR DESCRIPTION
Major changes:
- Add agents system (hook-runner, navigator, reporter, step-executor)
- Add hooks (pre-step, post-step) with agent:/skill: support
- Add execution modes (manual/auto) with --auto flag
- Remove approval system
- Support multiple concurrent tasks with task-slug

New files:
- plugins/siat/agents/*.md
- plugins/siat/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)