### PR TITLE
fix(siat): inherit parent model for step-executor and reporter agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,7 +38,7 @@
       "name": "siat",
       "source": "./plugins/siat",
       "description": "Spec-driven development workflow. Guides you through plan → implement steps with customizable workflow.",
-      "version": "3.1.1"
+      "version": "3.1.2"
     }
   ]
 }

--- a/plugins/siat/.claude-plugin/plugin.json
+++ b/plugins/siat/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "siat",
   "description": "Spec-driven development workflow. Guides you through customizable workflow steps with hooks and isolated execution.",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "author": {
     "name": "eatnug"
   },

--- a/plugins/siat/agents/reporter.md
+++ b/plugins/siat/agents/reporter.md
@@ -2,7 +2,6 @@
 name: siat-reporter
 description: Generate summary report after step execution and save it
 tools: Read, Write, Glob
-model: haiku
 ---
 
 # Reporter

--- a/plugins/siat/agents/step-executor.md
+++ b/plugins/siat/agents/step-executor.md
@@ -2,7 +2,6 @@
 name: siat-step-executor
 description: Execute a siat step in isolated context (for mode:agent)
 tools: Read, Write, Edit, Glob, Grep, Bash
-model: sonnet
 ---
 
 # Step Executor


### PR DESCRIPTION
## Summary
- Remove hardcoded `model: sonnet` from step-executor agent
- Remove hardcoded `model: haiku` from reporter agent
- Both agents now inherit the parent context's model for consistent reasoning quality

## Test plan
- [x] Verify agents work without explicit model specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)