### PR TITLE
feat(siat): v7.6.0 - Interactive Slack thread support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,7 +38,7 @@
       "name": "siat",
       "source": "./plugins/siat",
       "description": "Universal SDD framework. Linear workflow: specify → plan → implement → review.",
-      "version": "7.5.0"
+      "version": "7.6.0"
     }
   ]
 }

--- a/plugins/siat/.claude-plugin/plugin.json
+++ b/plugins/siat/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "siat",
   "description": "Universal SDD framework. Linear workflow: specify → plan → implement → review.",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "author": {
     "name": "eatnug"
   },

--- a/plugins/siat/commands/do.md
+++ b/plugins/siat/commands/do.md
@@ -40,6 +40,9 @@ siat 스킬의 `scripts/` 폴더:
 - `siat-post.sh` - 스텝 완료 후 검증 및 다음 스텝 계산
 - `siat-gh-issue.sh` - GitHub 이슈 생성
 - `siat-gh-pr.sh` - GitHub PR 생성
+- `siat-slack-notify.sh` - Slack 알림 (webhook, 단방향)
+- `siat-slack-thread.sh` - Slack 스레드 대화 (bot token, 양방향)
+- `siat-wait-approval.sh` - GitHub 이슈에서 승인 폴링
 
 **경로 참조:** `${CLAUDE_PLUGIN_ROOT}/skills/siat/scripts/` 사용
 
@@ -50,7 +53,7 @@ siat 스킬의 `scripts/` 폴더:
 
 ---
 
-## Config Format (v7.0)
+## Config Format (v7.2)
 
 ```yaml
 steps:
@@ -61,6 +64,12 @@ steps:
 
 output:
   path: ".claude/siat/specs"
+
+# Interactive 스텝 채널 (instruction.md에 interactive: true인 스텝)
+interactive:
+  channel: local           # local | slack
+  slack_bot_token: null    # xoxb-... (slack 채널용)
+  slack_channel_id: null   # C... or D... (slack 채널용)
 
 gateway:
   questions: local              # local or script:xxx.sh
@@ -76,14 +85,20 @@ hooks:
 
 presets:
   remote:
+    slack_webhook_url: null     # 알림용 (one-way)
+    interactive:
+      channel: slack
+      slack_bot_token: null     # 대화용 (two-way)
+      slack_channel_id: null
     gateway:
-      questions: script:gh-poll.sh {spec_path} --type=questions
-      feedback: script:gh-poll.sh {spec_path} --type=feedback
+      questions: local
+      feedback: script:siat-wait-approval.sh {spec_path}
     hooks:
       on_processed:
-        - script:gh-issue.sh {spec_path}
+        - script:siat-gh-issue.sh {spec_path}
+        - script:siat-slack-notify.sh {spec_path}
       on_approve:
-        - script:gh-issue-close.sh {spec_path}
+        - script:siat-gh-issue-close.sh {spec_path}
 ```
 
 ---
@@ -112,7 +127,7 @@ open_questions: []
 ${CLAUDE_PLUGIN_ROOT}/skills/siat/scripts/siat-pre.sh .claude/siat/config.yml "{step}" "{$ARGUMENTS}"
 ```
 
-**스크립트 출력 (JSON) - v7.1:**
+**스크립트 출력 (JSON) - v7.2:**
 ```json
 {
   "task_id": "login-page",
@@ -124,14 +139,20 @@ ${CLAUDE_PLUGIN_ROOT}/skills/siat/scripts/siat-pre.sh .claude/siat/config.yml "{
   "is_new_task": true,
   "remote_mode": true,
   "steps": ["specify", "plan", "implement", "review"],
+  "interactive": {
+    "enabled": true,
+    "channel": "slack",
+    "slack_bot_token": "xoxb-...",
+    "slack_channel_id": "D..."
+  },
   "gateway": {
     "mode": "remote",
-    "questions": "script:gh-poll.sh {spec_path} --type=questions",
-    "feedback": "script:gh-poll.sh {spec_path} --type=feedback"
+    "questions": "local",
+    "feedback": "script:siat-wait-approval.sh {spec_path}"
   },
   "hooks": {
-    "on_processed": ["script:gh-issue.sh {spec_path}"],
-    "on_approve": ["script:gh-issue-close.sh {spec_path}"]
+    "on_processed": ["script:siat-gh-issue.sh {spec_path}", "script:siat-slack-notify.sh {spec_path}"],
+    "on_approve": ["script:siat-gh-issue-close.sh {spec_path}"]
   },
   "frontmatter": {
     "id": "login-page",
@@ -167,10 +188,37 @@ ${CLAUDE_PLUGIN_ROOT}/skills/siat/scripts/siat-pre.sh .claude/siat/config.yml "{
 
 ### 4. Execute Step (AI 작업)
 
+**Interactive 스텝 분기 (CRITICAL):**
+
+`siat-pre.sh` 출력의 `interactive.enabled`가 `true`이면:
+
+**interactive.channel == "local":**
+- 기존처럼 `AskUserQuestion`으로 사용자와 대화
+- 터미널에서 실시간 대화
+
+**interactive.channel == "slack":**
+- `siat-slack-thread.sh`로 Slack 스레드에서 대화
+- 환경변수로 토큰 전달:
+  ```bash
+  SLACK_BOT_TOKEN="{interactive.slack_bot_token}" \
+  SLACK_CHANNEL_ID="{interactive.slack_channel_id}" \
+  siat-slack-thread.sh {spec_path} --init
+  ```
+- 질문 보내기: `--send "질문 내용"`
+- 답변 폴링: `--poll` (백그라운드로 실행)
+- 대화 완료 후 spec 문서 작성
+
+**Interactive 스텝이 아니면 (interactive.enabled == false):**
+- 분석/작업 수행 후 바로 spec 문서 작성
+- 질문은 `open_questions`에 기록, gateway.questions로 처리
+
+---
+
 **AI가 하는 일:**
 1. instruction.md 따라 분석/작업 수행
-2. spec_template.md 템플릿의 본문 섹션 작성
-3. `open_questions` 배열 작성 (미해결 질문)
+2. (Interactive 스텝) Slack/터미널에서 사용자와 대화하며 요구사항 명확화
+3. spec_template.md 템플릿의 본문 섹션 작성
+4. `open_questions` 배열 작성 (미해결 질문)
 
 **AI가 하지 않는 일 (스크립트가 처리):**
 - task_id 생성

--- a/plugins/siat/skills/siat/scripts/siat-pre.sh
+++ b/plugins/siat/skills/siat/scripts/siat-pre.sh
@@ -117,6 +117,24 @@ get_frontmatter_field() {
     ' "$file"
 }
 
+is_step_interactive() {
+    local config_path="$1"
+    local step="$2"
+    local config_dir
+    config_dir=$(dirname "$config_path")
+    local instruction_path="${config_dir}/steps/${step}/instruction.md"
+
+    if [[ -f "$instruction_path" ]]; then
+        local interactive_value
+        interactive_value=$(get_frontmatter_field "$instruction_path" "interactive")
+        if [[ "$interactive_value" == "true" ]]; then
+            echo "true"
+            return
+        fi
+    fi
+    echo "false"
+}
+
 get_step_index() {
     local target="$1"
     shift
@@ -282,6 +300,18 @@ fi
 SPEC_PATH="${TASK_DIR}/${STEP}.md"
 
 # ============================================================================
+# Parse Interactive Settings
+# ============================================================================
+
+STEP_INTERACTIVE=$(is_step_interactive "$CONFIG_PATH" "$STEP")
+
+# Default interactive settings
+INTERACTIVE_CHANNEL=$(parse_yaml_nested "$CONFIG_PATH" "interactive" "channel")
+INTERACTIVE_CHANNEL="${INTERACTIVE_CHANNEL:-local}"
+INTERACTIVE_SLACK_BOT_TOKEN=$(parse_yaml_nested "$CONFIG_PATH" "interactive" "slack_bot_token")
+INTERACTIVE_SLACK_CHANNEL_ID=$(parse_yaml_nested "$CONFIG_PATH" "interactive" "slack_channel_id")
+
+# ============================================================================
 # Parse Gateway and Hooks (based on mode)
 # ============================================================================
 
@@ -310,6 +340,57 @@ done < <(get_hooks_array "$CONFIG_PATH" "on_approve")
 
 # If remote mode, override with presets.remote
 if [[ "$REMOTE_MODE" == "true" ]]; then
+    # Parse presets.remote.interactive.channel
+    REMOTE_INTERACTIVE_CHANNEL=$(awk '
+        /^presets:/ { in_presets=1; next }
+        in_presets && /^[a-z]/ && !/^[[:space:]]/ { in_presets=0 }
+        in_presets && /remote:/ { in_remote=1; next }
+        in_remote && /^[[:space:]]{4}[a-z]/ && !/interactive/ { next }
+        in_remote && /interactive:/ { in_interactive=1; next }
+        in_interactive && /channel:/ {
+            gsub(/.*channel:[[:space:]]*/, "")
+            gsub(/"/, "")
+            print
+            exit
+        }
+    ' "$CONFIG_PATH")
+
+    [[ -n "$REMOTE_INTERACTIVE_CHANNEL" ]] && INTERACTIVE_CHANNEL="$REMOTE_INTERACTIVE_CHANNEL"
+
+    # Parse presets.remote.interactive.slack_bot_token
+    REMOTE_SLACK_BOT_TOKEN=$(awk '
+        /^presets:/ { in_presets=1; next }
+        in_presets && /^[a-z]/ && !/^[[:space:]]/ { in_presets=0 }
+        in_presets && /remote:/ { in_remote=1; next }
+        in_remote && /interactive:/ { in_interactive=1; next }
+        in_interactive && /^[[:space:]]+[a-z]/ && !/slack/ { next }
+        in_interactive && /slack_bot_token:/ {
+            gsub(/.*slack_bot_token:[[:space:]]*/, "")
+            gsub(/"/, "")
+            if ($0 != "null") print
+            exit
+        }
+    ' "$CONFIG_PATH")
+
+    # Parse presets.remote.interactive.slack_channel_id
+    REMOTE_SLACK_CHANNEL_ID=$(awk '
+        /^presets:/ { in_presets=1; next }
+        in_presets && /^[a-z]/ && !/^[[:space:]]/ { in_presets=0 }
+        in_presets && /remote:/ { in_remote=1; next }
+        in_remote && /interactive:/ { in_interactive=1; next }
+        in_interactive && /^[[:space:]]+[a-z]/ && !/slack/ { next }
+        in_interactive && /slack_channel_id:/ {
+            gsub(/.*slack_channel_id:[[:space:]]*/, "")
+            gsub(/"/, "")
+            if ($0 != "null") print
+            exit
+        }
+    ' "$CONFIG_PATH")
+
+    # Override slack settings if remote preset has values
+    [[ -n "$REMOTE_SLACK_BOT_TOKEN" ]] && INTERACTIVE_SLACK_BOT_TOKEN="$REMOTE_SLACK_BOT_TOKEN"
+    [[ -n "$REMOTE_SLACK_CHANNEL_ID" ]] && INTERACTIVE_SLACK_CHANNEL_ID="$REMOTE_SLACK_CHANNEL_ID"
+
     # Parse presets.remote.gateway
     REMOTE_QUESTIONS=$(awk '
         /^presets:/ { in_presets=1; next }
@@ -397,7 +478,7 @@ COMPLETED_JSON=$(printf '%s\n' "${COMPLETED_STEPS[@]}" | jq -R . | jq -s .)
 HOOKS_ON_PROCESSED_JSON=$(printf '%s\n' "${HOOKS_ON_PROCESSED[@]}" | jq -R . | jq -s .)
 HOOKS_ON_APPROVE_JSON=$(printf '%s\n' "${HOOKS_ON_APPROVE[@]}" | jq -R . | jq -s .)
 
-# Output JSON with v7.1 format (includes gateway and hooks)
+# Output JSON with v7.2 format (includes gateway, hooks, and interactive)
 jq -n \
     --arg task_id "$TASK_ID" \
     --arg step "$STEP" \
@@ -415,6 +496,10 @@ jq -n \
     --arg gw_feedback "$GATEWAY_FEEDBACK" \
     --argjson hooks_on_processed "$HOOKS_ON_PROCESSED_JSON" \
     --argjson hooks_on_approve "$HOOKS_ON_APPROVE_JSON" \
+    --argjson step_interactive "$STEP_INTERACTIVE" \
+    --arg interactive_channel "$INTERACTIVE_CHANNEL" \
+    --arg interactive_slack_bot_token "$INTERACTIVE_SLACK_BOT_TOKEN" \
+    --arg interactive_slack_channel_id "$INTERACTIVE_SLACK_CHANNEL_ID" \
     '{
         task_id: $task_id,
         step: $step,
@@ -428,6 +513,12 @@ jq -n \
         remote_mode: $remote_mode,
         steps: $steps,
         completed: $completed,
+        interactive: {
+            enabled: $step_interactive,
+            channel: $interactive_channel,
+            slack_bot_token: (if $interactive_slack_bot_token == "" or $interactive_slack_bot_token == "null" then null else $interactive_slack_bot_token end),
+            slack_channel_id: (if $interactive_slack_channel_id == "" or $interactive_slack_channel_id == "null" then null else $interactive_slack_channel_id end)
+        },
         gateway: {
             mode: (if $remote_mode then "remote" else "local" end),
             questions: $gw_questions,

--- a/plugins/siat/skills/siat/scripts/siat-slack-thread.sh
+++ b/plugins/siat/skills/siat/scripts/siat-slack-thread.sh
@@ -1,0 +1,392 @@
+#!/bin/bash
+# siat-slack-thread.sh - Interactive Slack thread for siat workflow
+# Enables real-time conversation in Slack threads for interactive steps
+#
+# Usage:
+#   siat-slack-thread.sh <spec_path> --init              # Create thread, save thread_ts
+#   siat-slack-thread.sh <spec_path> --send "<message>"  # Post to thread
+#   siat-slack-thread.sh <spec_path> --poll              # Poll for new replies
+#   siat-slack-thread.sh <spec_path> --type=questions    # Gateway mode: ask questions
+#   siat-slack-thread.sh <spec_path> --type=feedback     # Gateway mode: get feedback
+#
+# Required environment variables:
+#   SLACK_BOT_TOKEN   - Bot User OAuth Token (xoxb-...)
+#   SLACK_CHANNEL_ID  - Channel ID to post in
+#
+# Optional:
+#   SIAT_SLACK_POLL_INTERVAL - Poll interval in seconds (default: 5)
+#   SIAT_SLACK_POLL_TIMEOUT  - Poll timeout in seconds (default: 300)
+
+set -e
+
+SPEC_PATH="$1"
+shift
+
+# Parse arguments
+ACTION=""
+MESSAGE=""
+GATEWAY_TYPE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --init)
+            ACTION="init"
+            shift
+            ;;
+        --send)
+            ACTION="send"
+            MESSAGE="$2"
+            shift 2
+            ;;
+        --poll)
+            ACTION="poll"
+            shift
+            ;;
+        --type=*)
+            GATEWAY_TYPE="${1#--type=}"
+            ACTION="gateway"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# Validate environment
+if [[ -z "$SLACK_BOT_TOKEN" ]]; then
+    echo '{"error": "SLACK_BOT_TOKEN not set"}' | jq .
+    exit 1
+fi
+
+if [[ -z "$SLACK_CHANNEL_ID" ]]; then
+    echo '{"error": "SLACK_CHANNEL_ID not set"}' | jq .
+    exit 1
+fi
+
+# Config
+POLL_INTERVAL="${SIAT_SLACK_POLL_INTERVAL:-5}"
+POLL_TIMEOUT="${SIAT_SLACK_POLL_TIMEOUT:-300}"
+
+# Thread state file (stored alongside spec)
+SPEC_DIR=$(dirname "$SPEC_PATH")
+THREAD_STATE="${SPEC_DIR}/.slack_thread.json"
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+slack_api() {
+    local method="$1"
+    local endpoint="$2"
+    local data="$3"
+
+    if [[ "$method" == "GET" ]]; then
+        curl -s -X GET \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://slack.com/api/${endpoint}"
+    else
+        curl -s -X POST \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$data" \
+            "https://slack.com/api/${endpoint}"
+    fi
+}
+
+get_thread_ts() {
+    if [[ -f "$THREAD_STATE" ]]; then
+        jq -r '.thread_ts // empty' "$THREAD_STATE"
+    fi
+}
+
+get_last_ts() {
+    if [[ -f "$THREAD_STATE" ]]; then
+        jq -r '.last_ts // empty' "$THREAD_STATE"
+    fi
+}
+
+save_thread_state() {
+    local thread_ts="$1"
+    local last_ts="$2"
+    jq -n \
+        --arg thread_ts "$thread_ts" \
+        --arg last_ts "$last_ts" \
+        --arg channel "$SLACK_CHANNEL_ID" \
+        --arg spec_path "$SPEC_PATH" \
+        '{
+            thread_ts: $thread_ts,
+            last_ts: $last_ts,
+            channel: $channel,
+            spec_path: $spec_path,
+            updated_at: now | todate
+        }' > "$THREAD_STATE"
+}
+
+extract_spec_info() {
+    local spec_path="$1"
+    local task_id=""
+    local step=""
+
+    if [[ -f "$spec_path" ]]; then
+        task_id=$(awk '/^---$/{if(in_fm)exit;in_fm=1;next} in_fm&&/^id:/{gsub(/^id:[[:space:]]*/,"");gsub(/"/,"");print;exit}' "$spec_path")
+        step=$(awk '/^---$/{if(in_fm)exit;in_fm=1;next} in_fm&&/^step:/{gsub(/^step:[[:space:]]*/,"");gsub(/"/,"");print;exit}' "$spec_path")
+    fi
+
+    echo "${task_id:-unknown}|${step:-unknown}"
+}
+
+# ============================================================================
+# Actions
+# ============================================================================
+
+do_init() {
+    local spec_info
+    spec_info=$(extract_spec_info "$SPEC_PATH")
+    local task_id="${spec_info%|*}"
+    local step="${spec_info#*|}"
+
+    # Create initial message
+    local init_message="*[Siat] ${task_id} - ${step}*
+
+Interactive step started. Please respond in this thread.
+
+---
+_Waiting for questions..._"
+
+    local response
+    response=$(slack_api "POST" "chat.postMessage" "$(jq -n \
+        --arg channel "$SLACK_CHANNEL_ID" \
+        --arg text "$init_message" \
+        '{channel: $channel, text: $text, mrkdwn: true}'
+    )")
+
+    local ok
+    ok=$(echo "$response" | jq -r '.ok')
+
+    if [[ "$ok" != "true" ]]; then
+        echo "$response" | jq '{error: .error, response: .}'
+        exit 1
+    fi
+
+    local thread_ts
+    thread_ts=$(echo "$response" | jq -r '.ts')
+
+    save_thread_state "$thread_ts" "$thread_ts"
+
+    jq -n \
+        --arg thread_ts "$thread_ts" \
+        --arg channel "$SLACK_CHANNEL_ID" \
+        --arg task_id "$task_id" \
+        --arg step "$step" \
+        '{
+            success: true,
+            thread_ts: $thread_ts,
+            channel: $channel,
+            task_id: $task_id,
+            step: $step
+        }'
+}
+
+do_send() {
+    local thread_ts
+    thread_ts=$(get_thread_ts)
+
+    if [[ -z "$thread_ts" ]]; then
+        echo '{"error": "No thread initialized. Run --init first."}' | jq .
+        exit 1
+    fi
+
+    local response
+    response=$(slack_api "POST" "chat.postMessage" "$(jq -n \
+        --arg channel "$SLACK_CHANNEL_ID" \
+        --arg text "$MESSAGE" \
+        --arg thread_ts "$thread_ts" \
+        '{channel: $channel, text: $text, thread_ts: $thread_ts, mrkdwn: true}'
+    )")
+
+    local ok
+    ok=$(echo "$response" | jq -r '.ok')
+
+    if [[ "$ok" != "true" ]]; then
+        echo "$response" | jq '{error: .error, response: .}'
+        exit 1
+    fi
+
+    local msg_ts
+    msg_ts=$(echo "$response" | jq -r '.ts')
+
+    # Update last_ts
+    save_thread_state "$thread_ts" "$msg_ts"
+
+    jq -n \
+        --arg ts "$msg_ts" \
+        --arg thread_ts "$thread_ts" \
+        '{success: true, ts: $ts, thread_ts: $thread_ts}'
+}
+
+do_poll() {
+    local thread_ts
+    thread_ts=$(get_thread_ts)
+
+    if [[ -z "$thread_ts" ]]; then
+        echo '{"error": "No thread initialized. Run --init first."}' | jq .
+        exit 1
+    fi
+
+    local last_ts
+    last_ts=$(get_last_ts)
+    last_ts="${last_ts:-$thread_ts}"
+
+    local start_time
+    start_time=$(date +%s)
+
+    while true; do
+        local now
+        now=$(date +%s)
+        local elapsed=$((now - start_time))
+
+        if [[ $elapsed -ge $POLL_TIMEOUT ]]; then
+            jq -n '{timeout: true, elapsed: '$elapsed'}'
+            exit 0
+        fi
+
+        # Get thread replies
+        local response
+        response=$(slack_api "GET" "conversations.replies?channel=${SLACK_CHANNEL_ID}&ts=${thread_ts}&oldest=${last_ts}")
+
+        local ok
+        ok=$(echo "$response" | jq -r '.ok')
+
+        if [[ "$ok" != "true" ]]; then
+            echo "$response" | jq '{error: .error, response: .}'
+            exit 1
+        fi
+
+        # Find new messages (not from bot, after last_ts)
+        local bot_id
+        bot_id=$(slack_api "GET" "auth.test" | jq -r '.user_id')
+
+        local new_messages
+        new_messages=$(echo "$response" | jq --arg last_ts "$last_ts" --arg bot_id "$bot_id" '
+            .messages
+            | map(select(.ts > $last_ts and .user != $bot_id and .bot_id == null))
+        ')
+
+        local count
+        count=$(echo "$new_messages" | jq 'length')
+
+        if [[ "$count" -gt 0 ]]; then
+            # Get the latest message
+            local latest
+            latest=$(echo "$new_messages" | jq '.[0]')
+            local latest_ts
+            latest_ts=$(echo "$latest" | jq -r '.ts')
+            local latest_text
+            latest_text=$(echo "$latest" | jq -r '.text')
+            local latest_user
+            latest_user=$(echo "$latest" | jq -r '.user')
+
+            # Update last_ts
+            save_thread_state "$thread_ts" "$latest_ts"
+
+            jq -n \
+                --arg text "$latest_text" \
+                --arg user "$latest_user" \
+                --arg ts "$latest_ts" \
+                --argjson all_new "$new_messages" \
+                '{
+                    success: true,
+                    message: {
+                        text: $text,
+                        user: $user,
+                        ts: $ts
+                    },
+                    all_messages: $all_new
+                }'
+            exit 0
+        fi
+
+        sleep "$POLL_INTERVAL"
+    done
+}
+
+do_gateway() {
+    local thread_ts
+    thread_ts=$(get_thread_ts)
+
+    # Initialize thread if not exists
+    if [[ -z "$thread_ts" ]]; then
+        do_init > /dev/null
+        thread_ts=$(get_thread_ts)
+    fi
+
+    case "$GATEWAY_TYPE" in
+        questions)
+            # Read questions from stdin or spec file
+            # For now, just poll for response
+            do_poll
+            ;;
+        feedback)
+            # Post completion message and wait for feedback
+            do_send <<< "Step completed. Please review and respond:
+- \`/approve\` - Accept and continue
+- \`/revise <feedback>\` - Request changes
+- \`/reject\` - Stop workflow"
+
+            # Poll for feedback response
+            local response
+            response=$(do_poll)
+
+            local text
+            text=$(echo "$response" | jq -r '.message.text // empty')
+
+            if [[ -z "$text" ]]; then
+                echo "$response"
+                exit 0
+            fi
+
+            # Parse feedback commands
+            if [[ "$text" =~ ^/approve ]]; then
+                jq -n '{action: "approve", raw: "'"$text"'"}'
+            elif [[ "$text" =~ ^/revise[[:space:]]*(.*) ]]; then
+                local feedback="${text#/revise}"
+                feedback="${feedback#"${feedback%%[![:space:]]*}"}"
+                jq -n --arg feedback "$feedback" '{action: "revise", feedback: $feedback, raw: "'"$text"'"}'
+            elif [[ "$text" =~ ^/reject ]]; then
+                jq -n '{action: "reject", raw: "'"$text"'"}'
+            else
+                # Treat as general feedback for revision
+                jq -n --arg feedback "$text" '{action: "feedback", feedback: $feedback, raw: "'"$text"'"}'
+            fi
+            ;;
+        *)
+            echo '{"error": "Unknown gateway type: '"$GATEWAY_TYPE"'"}' | jq .
+            exit 1
+            ;;
+    esac
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+case "$ACTION" in
+    init)
+        do_init
+        ;;
+    send)
+        do_send
+        ;;
+    poll)
+        do_poll
+        ;;
+    gateway)
+        do_gateway
+        ;;
+    *)
+        echo '{"error": "No action specified. Use --init, --send, --poll, or --type=<questions|feedback>"}' | jq .
+        exit 1
+        ;;
+esac

--- a/plugins/siat/templates/config.yml
+++ b/plugins/siat/templates/config.yml
@@ -12,7 +12,14 @@ steps:
 output:
   path: ".claude/siat/specs"
 
-# Gateway: 사용자 상호작용 채널
+# Interactive 스텝 채널 (instruction.md에 interactive: true인 스텝)
+interactive:
+  channel: local           # local | slack
+  # Slack settings (required when channel: slack)
+  slack_bot_token: null    # Bot User OAuth Token (xoxb-...)
+  slack_channel_id: null   # Channel ID to create threads in
+
+# Gateway: 사용자 상호작용 채널 (비-interactive 스텝)
 gateway:
   questions: local    # local = AskUserQuestion, script:xxx.sh
   feedback: local     # local = AskUserQuestion, script:xxx.sh
@@ -29,6 +36,13 @@ hooks:
 # Presets: 자주 쓰는 설정 묶음
 presets:
   remote:
+    # Slack notification (webhook - one-way alerts)
+    slack_webhook_url: null    # https://hooks.slack.com/services/...
+    # Slack interactive (bot token - two-way conversation)
+    interactive:
+      channel: slack
+      slack_bot_token: null    # xoxb-...
+      slack_channel_id: null   # C... or D...
     gateway:
       questions: local
       feedback: script:siat-wait-approval.sh {spec_path}

--- a/plugins/siat/templates/steps/specify/instruction.md
+++ b/plugins/siat/templates/steps/specify/instruction.md
@@ -1,3 +1,7 @@
+---
+interactive: true
+---
+
 # Specify (요구사항 명세)
 
 당신은 **시니어 제품 분석가 (Senior Product Analyst)** 입니다.


### PR DESCRIPTION
- Add interactive step concept (instruction.md frontmatter: interactive: true)
- Add siat-slack-thread.sh for two-way Slack conversation
- siat-pre.sh parses interactive settings from config/preset
- Config supports slack_bot_token, slack_channel_id for interactive steps
- do.md updated with interactive step handling logic
- Separate webhook (notify) vs bot token (thread) Slack integrations